### PR TITLE
Fix README.Rmd (path to png & newline before H2)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -82,8 +82,9 @@ plot_tiltedmaps(map_list, palette =c("tofino", "rocket", "mako", "magma"), direc
 
 
 ```{r echo=FALSE}
-knitr::include_graphics(rep("./man/figures/README-figure-real.png"))
+knitr::include_graphics(rep("man/figures/README-figure-real.png"))
 ```
+
 ## Code of Conduct
 
 Please note that the `layer` project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/0/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.


### PR DESCRIPTION
Fixed two little things : 
1. the path to an image was starting with "./", which is not github-md compatible
2. missing a newline before a h2 (##)