### PR TITLE
remove rgeos dependency by replacing rgeos::gBuffer with sf::st_buffer, fixes #15

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,5 +25,4 @@ Imports:
     magrittr,
     tidyr,
     furrr,
-    rgeos
 LazyData: true

--- a/R/tilt_maps.R
+++ b/R/tilt_maps.R
@@ -91,7 +91,7 @@ create_outline <- function(outline_from, outline_to){
     outline_to <- sf::st_as_sf(outline_to)
   }
   
-  outline_shape <- rgeos::gBuffer(sf::as_Spatial(outline_from), byid = FALSE, width = 0) 
+  outline_shape <- sf::st_union(sf::st_buffer(outline_from, dist = 0))
   outline_shape <- sf::st_as_sf(sf::st_cast(sf::st_as_sf(outline_shape), 'MULTILINESTRING'))
   
   current = attr(outline_shape, "sf_column")


### PR DESCRIPTION
Fixes #15 .

I have replaced `rgeos::gBuffer` with `sf::st_buffer` effectively removing the dependency on deprecated `rgeos` package. This solves the issue with not being able to install the package even from GitHub, as `rgeos` is not installable anymore without some hoops. Hopefully, this will also help with restoring the package to CRAN.